### PR TITLE
Review diff for change

### DIFF
--- a/src/EditorFeatures/Core/Classification/Semantic/ClassificationUtilities.cs
+++ b/src/EditorFeatures/Core/Classification/Semantic/ClassificationUtilities.cs
@@ -195,12 +195,12 @@ namespace Microsoft.CodeAnalysis.Classification
         {
             if (type == ClassificationType.Semantic)
             {
-                await classificationService.ToBeRemovedAsync(
+                await classificationService.AddSemanticToBeRemovedAsync(
                    document, snapshotSpan.Span.ToTextSpan(), options, classifiedSpans, cancellationToken).ConfigureAwait(false);
             }
             else if (type == ClassificationType.EmbeddedLanguage)
             {
-                await classificationService.AddEmbeddedLanguageClassificationsAsync(
+                await classificationService.AddEmbeddedToBeRemovedAsync(
                    document, snapshotSpan.Span.ToTextSpan(), options, classifiedSpans, cancellationToken).ConfigureAwait(false);
             }
             else

--- a/src/EditorFeatures/Core/Classification/Semantic/ClassificationUtilities.cs
+++ b/src/EditorFeatures/Core/Classification/Semantic/ClassificationUtilities.cs
@@ -195,7 +195,7 @@ namespace Microsoft.CodeAnalysis.Classification
         {
             if (type == ClassificationType.Semantic)
             {
-                await classificationService.AddSemanticClassificationsAsync(
+                await classificationService.ToBeRemovedAsync(
                    document, snapshotSpan.Span.ToTextSpan(), options, classifiedSpans, cancellationToken).ConfigureAwait(false);
             }
             else if (type == ClassificationType.EmbeddedLanguage)

--- a/src/EditorFeatures/Test2/Classification/ClassificationTests.vb
+++ b/src/EditorFeatures/Test2/Classification/ClassificationTests.vb
@@ -2,6 +2,7 @@
 ' The .NET Foundation licenses this file to you under the MIT license.
 ' See the LICENSE file in the project root for more information.
 
+Imports System.Collections.Immutable
 Imports System.Composition
 Imports System.Threading
 Imports Microsoft.CodeAnalysis.Classification
@@ -330,7 +331,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Classification
                 ' make sure we don't crash with wrong document
                 Dim result = New SegmentedList(Of ClassifiedSpan)()
                 Await classificationService.AddSyntacticClassificationsAsync(wrongDocument, New TextSpan(0, text.Length), result, CancellationToken.None)
-                Await classificationService.AddSemanticClassificationsAsync(wrongDocument, New TextSpan(0, text.Length), options:=Nothing, result, CancellationToken.None)
+                Await classificationService.ToBeRemovedAsync(wrongDocument, New TextSpan(0, text.Length), options:=Nothing, result, CancellationToken.None)
             End Using
         End Function
 
@@ -349,7 +350,11 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Classification
             Public Sub AddSyntacticClassifications(services As SolutionServices, root As SyntaxNode, textSpan As TextSpan, result As SegmentedList(Of ClassifiedSpan), cancellationToken As CancellationToken) Implements IClassificationService.AddSyntacticClassifications
             End Sub
 
-            Public Function AddSemanticClassificationsAsync(document As Document, textSpan As TextSpan, options As ClassificationOptions, result As SegmentedList(Of ClassifiedSpan), cancellationToken As CancellationToken) As Task Implements IClassificationService.AddSemanticClassificationsAsync
+            Public Function AddSemanticClassificationsAsync(document As Document, textSpans As ImmutableArray(Of TextSpan), options As ClassificationOptions, result As ArrayBuilder(Of SegmentedList(Of ClassifiedSpan)), cancellationToken As CancellationToken) As Task Implements IClassificationService.AddSemanticClassificationsAsync
+                Return Task.CompletedTask
+            End Function
+
+            Public Function ToBeRemovedAsync(document As Document, textSpan As TextSpan, options As ClassificationOptions, result As SegmentedList(Of ClassifiedSpan), cancellationToken As CancellationToken) As Task Implements IClassificationService.ToBeRemovedAsync
                 Return Task.CompletedTask
             End Function
 

--- a/src/EditorFeatures/Test2/Classification/ClassificationTests.vb
+++ b/src/EditorFeatures/Test2/Classification/ClassificationTests.vb
@@ -350,7 +350,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Classification
             Public Sub AddSyntacticClassifications(services As SolutionServices, root As SyntaxNode, textSpan As TextSpan, result As SegmentedList(Of ClassifiedSpan), cancellationToken As CancellationToken) Implements IClassificationService.AddSyntacticClassifications
             End Sub
 
-            Public Function AddSemanticClassificationsAsync(document As Document, textSpans As ImmutableArray(Of TextSpan), options As ClassificationOptions, result As ArrayBuilder(Of SegmentedList(Of ClassifiedSpan)), cancellationToken As CancellationToken) As Task Implements IClassificationService.AddSemanticClassificationsAsync
+            Public Function AddSemanticClassificationsAsync(document As Document, textSpans As ImmutableArray(Of TextSpan), options As ClassificationOptions, result As ArrayBuilder(Of PooledObject(Of SegmentedList(Of ClassifiedSpan))), cancellationToken As CancellationToken) As Task Implements IClassificationService.AddSemanticClassificationsAsync
                 Return Task.CompletedTask
             End Function
 

--- a/src/EditorFeatures/Test2/Classification/ClassificationTests.vb
+++ b/src/EditorFeatures/Test2/Classification/ClassificationTests.vb
@@ -331,7 +331,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Classification
                 ' make sure we don't crash with wrong document
                 Dim result = New SegmentedList(Of ClassifiedSpan)()
                 Await classificationService.AddSyntacticClassificationsAsync(wrongDocument, New TextSpan(0, text.Length), result, CancellationToken.None)
-                Await classificationService.ToBeRemovedAsync(wrongDocument, New TextSpan(0, text.Length), options:=Nothing, result, CancellationToken.None)
+                Await classificationService.AddSemanticToBeRemovedAsync(wrongDocument, New TextSpan(0, text.Length), options:=Nothing, result, CancellationToken.None)
             End Using
         End Function
 
@@ -354,7 +354,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Classification
                 Return Task.CompletedTask
             End Function
 
-            Public Function ToBeRemovedAsync(document As Document, textSpan As TextSpan, options As ClassificationOptions, result As SegmentedList(Of ClassifiedSpan), cancellationToken As CancellationToken) As Task Implements IClassificationService.ToBeRemovedAsync
+            Public Function AddSemanticToBeRemovedAsync(document As Document, textSpan As TextSpan, options As ClassificationOptions, result As SegmentedList(Of ClassifiedSpan), cancellationToken As CancellationToken) As Task Implements IClassificationService.AddSemanticToBeRemovedAsync
                 Return Task.CompletedTask
             End Function
 
@@ -373,7 +373,11 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Classification
                 Return Nothing
             End Function
 
-            Public Function AddEmbeddedLanguageClassificationsAsync(document As Document, textSpan As TextSpan, options As ClassificationOptions, result As SegmentedList(Of ClassifiedSpan), cancellationToken As CancellationToken) As Task Implements IClassificationService.AddEmbeddedLanguageClassificationsAsync
+            Public Function AddEmbeddedLanguageClassificationsAsync(document As Document, textSpans As ImmutableArray(Of TextSpan), options As ClassificationOptions, result As ArrayBuilder(Of PooledObject(Of SegmentedList(Of ClassifiedSpan))), cancellationToken As CancellationToken) As Task Implements IClassificationService.AddEmbeddedLanguageClassificationsAsync
+                Return Task.CompletedTask
+            End Function
+
+            Public Function AddEmbeddedToBeRemovedAsync(document As Document, textSpan As TextSpan, options As ClassificationOptions, result As SegmentedList(Of ClassifiedSpan), cancellationToken As CancellationToken) As Task Implements IClassificationService.AddEmbeddedToBeRemovedAsync
                 Return Task.CompletedTask
             End Function
         End Class

--- a/src/EditorFeatures/TestUtilities/Classification/AbstractClassifierTests.cs
+++ b/src/EditorFeatures/TestUtilities/Classification/AbstractClassifierTests.cs
@@ -274,8 +274,8 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Classification
             var options = ClassificationOptions.Default;
 
             using var _ = Classifier.GetPooledList(out var result);
-            await service.ToBeRemovedAsync(document, span, options, result, CancellationToken.None);
-            await service.AddEmbeddedLanguageClassificationsAsync(document, span, options, result, CancellationToken.None);
+            await service.AddSemanticToBeRemovedAsync(document, span, options, result, CancellationToken.None);
+            await service.AddEmbeddedToBeRemovedAsync(document, span, options, result, CancellationToken.None);
             return result.ToImmutableArray();
         }
 

--- a/src/EditorFeatures/TestUtilities/Classification/AbstractClassifierTests.cs
+++ b/src/EditorFeatures/TestUtilities/Classification/AbstractClassifierTests.cs
@@ -274,7 +274,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Classification
             var options = ClassificationOptions.Default;
 
             using var _ = Classifier.GetPooledList(out var result);
-            await service.AddSemanticClassificationsAsync(document, span, options, result, CancellationToken.None);
+            await service.ToBeRemovedAsync(document, span, options, result, CancellationToken.None);
             await service.AddEmbeddedLanguageClassificationsAsync(document, span, options, result, CancellationToken.None);
             return result.ToImmutableArray();
         }

--- a/src/Features/Core/Portable/EmbeddedLanguages/Classification/AbstractEmbeddedLanguageClassificationService.cs
+++ b/src/Features/Core/Portable/EmbeddedLanguages/Classification/AbstractEmbeddedLanguageClassificationService.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Collections;
@@ -35,13 +36,25 @@ namespace Microsoft.CodeAnalysis.Classification
             _fallbackClassifier = fallbackClassifier;
         }
 
-        public async Task AddEmbeddedLanguageClassificationsAsync(
+        public async Task AddEmbeddedToBeRemovedAsync(
             Document document, TextSpan textSpan, ClassificationOptions options, SegmentedList<ClassifiedSpan> result, CancellationToken cancellationToken)
         {
             var semanticModel = await document.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
             var project = document.Project;
             AddEmbeddedLanguageClassifications(
                 project.Solution.Services, project, semanticModel, textSpan, options, result, cancellationToken);
+        }
+
+        public async Task AddEmbeddedLanguageClassificationsAsync(
+            Document document, ImmutableArray<TextSpan> textSpans, ClassificationOptions options, ArrayBuilder<PooledObject<SegmentedList<ClassifiedSpan>>> result, CancellationToken cancellationToken)
+        {
+            var semanticModel = await document.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+            var project = document.Project;
+            for (var i = 0; i < textSpans.Length; i++)
+            {
+                AddEmbeddedLanguageClassifications(
+                    project.Solution.Services, project, semanticModel, textSpans[i], options, result[i].Object, cancellationToken);
+            }
         }
 
         public void AddEmbeddedLanguageClassifications(

--- a/src/Features/LanguageServer/Protocol/Handler/SemanticTokens/SemanticTokensHelpers.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/SemanticTokens/SemanticTokensHelpers.cs
@@ -4,6 +4,8 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -81,14 +83,14 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.SemanticTokens
             // We either calculate the tokens for the full document span, or the user 
             // can pass in a range from the full document if they wish.
             ranges ??= new[] { ProtocolConversions.TextSpanToRange(root.FullSpan, text) };
-
-            foreach (var range in ranges)
+            using var _ = ArrayBuilder<TextSpan>.GetInstance(out var textSpans);
+            for (var i = 0; i < ranges.Length; i++)
             {
-                var textSpan = ProtocolConversions.RangeToTextSpan(range, text);
-
-                await GetClassifiedSpansForDocumentAsync(
-                    classifiedSpans, document, textSpan, options, cancellationToken).ConfigureAwait(false);
+                textSpans.Add(ProtocolConversions.RangeToTextSpan(ranges[i], text));
             }
+
+            await GetClassifiedSpansForDocumentAsync(
+                classifiedSpans, document, textSpans.ToImmutable(), options, cancellationToken).ConfigureAwait(false);
 
             // Classified spans are not guaranteed to be returned in a certain order so we sort them to be safe.
             classifiedSpans.Sort(ClassifiedSpanComparer.Instance);
@@ -105,7 +107,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.SemanticTokens
         private static async Task GetClassifiedSpansForDocumentAsync(
             SegmentedList<ClassifiedSpan> classifiedSpans,
             Document document,
-            TextSpan textSpan,
+            ImmutableArray<TextSpan> textSpans,
             ClassificationOptions options,
             CancellationToken cancellationToken)
         {
@@ -116,7 +118,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.SemanticTokens
 
             // `includeAdditiveSpans` will add token modifiers such as 'static', which we want to include in LSP.
             var spans = await ClassifierHelper.GetClassifiedSpansAsync(
-                document, textSpan, options, includeAdditiveSpans: true, cancellationToken).ConfigureAwait(false);
+                document, textSpans, options, includeAdditiveSpans: true, cancellationToken).ConfigureAwait(false);
 
             // The spans returned to us may include some empty spans, which we don't care about. We also don't care
             // about the 'text' classification.  It's added for everything between real classifications (including

--- a/src/Features/LanguageServer/Protocol/Handler/SemanticTokens/SemanticTokensHelpers.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/SemanticTokens/SemanticTokensHelpers.cs
@@ -25,7 +25,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.SemanticTokens
     internal class SemanticTokensHelpers
     {
         private static Random s_random = new Random();
-        private static bool s_stopExperiment = true;
+        private static bool s_stopExperiment = false;
         private static List<long> s_old = new List<long>();
         private static List<long> s_new = new List<long>();
 

--- a/src/Features/LanguageServer/Protocol/Handler/SemanticTokens/SemanticTokensHelpers.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/SemanticTokens/SemanticTokensHelpers.cs
@@ -25,6 +25,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.SemanticTokens
     internal class SemanticTokensHelpers
     {
         private static Random s_random = new Random();
+        private static bool s_stopExperiment = true;
         private static List<long> s_old = new List<long>();
         private static List<long> s_new = new List<long>();
 
@@ -87,7 +88,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.SemanticTokens
             // We either calculate the tokens for the full document span, or the user 
             // can pass in a range from the full document if they wish.
             ranges ??= new[] { ProtocolConversions.TextSpanToRange(root.FullSpan, text) };
-            if (s_random.Next(2) == 0)
+            if (s_stopExperiment || s_random.Next(2) == 0)
             {
                 var stopwatch = Stopwatch.StartNew();
                 using var _ = ArrayBuilder<TextSpan>.GetInstance(out var textSpans);

--- a/src/Tools/ExternalAccess/FSharp/Internal/Classification/FSharpClassificationService.cs
+++ b/src/Tools/ExternalAccess/FSharp/Internal/Classification/FSharpClassificationService.cs
@@ -46,17 +46,9 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp.Internal.Classification
             result.AddRange(list);
         }
 
-        public async Task AddSemanticClassificationsAsync(Document document, ImmutableArray<TextSpan> textSpans, ClassificationOptions options, ArrayBuilder<SegmentedList<ClassifiedSpan>> result, CancellationToken cancellationToken)
+        public async Task AddSemanticClassificationsAsync(Document document, ImmutableArray<TextSpan> textSpans, ClassificationOptions options, ArrayBuilder<PooledObject<SegmentedList<ClassifiedSpan>>> result, CancellationToken cancellationToken)
         {
-            using var _1 = Classifier.GetPooledList(out var semanticSpans);
-            using var _2 = ArrayBuilder<SegmentedList<ClassifiedSpan>>.GetInstance(out var semanticSpansArray);
-
-            for (var i = 0; i < textSpans.Length; i++)
-            {
-                var span = textSpans[i];
-                await ToBeRemovedAsync(document, span, options, semanticSpans, cancellationToken).ConfigureAwait(false);
-                semanticSpansArray.Add(semanticSpans);
-            }
+            throw new NotImplementedException();
         }
 
         public async Task AddSyntacticClassificationsAsync(Document document, TextSpan textSpan, SegmentedList<ClassifiedSpan> result, CancellationToken cancellationToken)

--- a/src/Tools/ExternalAccess/FSharp/Internal/Classification/FSharpClassificationService.cs
+++ b/src/Tools/ExternalAccess/FSharp/Internal/Classification/FSharpClassificationService.cs
@@ -39,7 +39,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp.Internal.Classification
             result.AddRange(list);
         }
 
-        public async Task ToBeRemovedAsync(Document document, TextSpan textSpan, ClassificationOptions options, SegmentedList<ClassifiedSpan> result, CancellationToken cancellationToken)
+        public async Task AddSemanticToBeRemovedAsync(Document document, TextSpan textSpan, ClassificationOptions options, SegmentedList<ClassifiedSpan> result, CancellationToken cancellationToken)
         {
             using var _ = s_listPool.GetPooledObject(out var list);
             await _service.AddSemanticClassificationsAsync(document, textSpan, list, cancellationToken).ConfigureAwait(false);
@@ -80,7 +80,12 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp.Internal.Classification
             return new();
         }
 
-        public Task AddEmbeddedLanguageClassificationsAsync(Document document, TextSpan textSpan, ClassificationOptions options, SegmentedList<ClassifiedSpan> result, CancellationToken cancellationToken)
+        public async Task AddEmbeddedLanguageClassificationsAsync(Document document, ImmutableArray<TextSpan> textSpans, ClassificationOptions options, ArrayBuilder<PooledObject<SegmentedList<ClassifiedSpan>>> result, CancellationToken cancellationToken)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task AddEmbeddedToBeRemovedAsync(Document document, TextSpan textSpan, ClassificationOptions options, SegmentedList<ClassifiedSpan> result, CancellationToken cancellationToken)
         {
             return Task.CompletedTask;
         }

--- a/src/Tools/IdeBenchmarks/RegexClassifierBenchmarks.cs
+++ b/src/Tools/IdeBenchmarks/RegexClassifierBenchmarks.cs
@@ -85,7 +85,7 @@ class Program
 
             using var _ = Classifier.GetPooledList(out var results);
 
-            await service.ToBeRemovedAsync(
+            await service.AddSemanticToBeRemovedAsync(
                 document,
                 span,
                 ClassificationOptions.Default,

--- a/src/Tools/IdeBenchmarks/RegexClassifierBenchmarks.cs
+++ b/src/Tools/IdeBenchmarks/RegexClassifierBenchmarks.cs
@@ -85,7 +85,7 @@ class Program
 
             using var _ = Classifier.GetPooledList(out var results);
 
-            await service.AddSemanticClassificationsAsync(
+            await service.ToBeRemovedAsync(
                 document,
                 span,
                 ClassificationOptions.Default,

--- a/src/Tools/IdeCoreBenchmarks/ClassificationBenchmarks.cs
+++ b/src/Tools/IdeCoreBenchmarks/ClassificationBenchmarks.cs
@@ -97,7 +97,7 @@ namespace IdeCoreBenchmarks
         {
             var service = document.GetRequiredLanguageService<IClassificationService>();
             using var _ = Classifier.GetPooledList(out var result);
-            await service.AddSemanticClassificationsAsync(document, span, ClassificationOptions.Default, result, CancellationToken.None);
+            await service.ToBeRemovedAsync(document, span, ClassificationOptions.Default, result, CancellationToken.None);
             return result.ToImmutableArray();
         }
 

--- a/src/Tools/IdeCoreBenchmarks/ClassificationBenchmarks.cs
+++ b/src/Tools/IdeCoreBenchmarks/ClassificationBenchmarks.cs
@@ -97,7 +97,7 @@ namespace IdeCoreBenchmarks
         {
             var service = document.GetRequiredLanguageService<IClassificationService>();
             using var _ = Classifier.GetPooledList(out var result);
-            await service.ToBeRemovedAsync(document, span, ClassificationOptions.Default, result, CancellationToken.None);
+            await service.AddSemanticToBeRemovedAsync(document, span, ClassificationOptions.Default, result, CancellationToken.None);
             return result.ToImmutableArray();
         }
 

--- a/src/Workspaces/Core/Portable/Classification/AbstractClassificationService.cs
+++ b/src/Workspaces/Core/Portable/Classification/AbstractClassificationService.cs
@@ -49,119 +49,6 @@ namespace Microsoft.CodeAnalysis.Classification
             return AddClassificationsInCurrentProcessAsync(document, textSpans, options, ClassificationType.EmbeddedLanguage, result, cancellationToken);
         }
 
-        private static async Task AddClassificationsInCurrentProcessAsync(
-            Document document,
-            ImmutableArray<TextSpan> textSpans,
-            ClassificationOptions options,
-            ClassificationType type,
-            ArrayBuilder<PooledObject<SegmentedList<ClassifiedSpan>>> result,
-            CancellationToken cancellationToken)
-        {
-            var classificationService = document.GetLanguageService<ISyntaxClassificationService>();
-            if (classificationService == null)
-            {
-                return;
-            }
-
-            if (type == ClassificationType.Semantic)
-            {
-                var reassignedVariableService = document.GetRequiredLanguageService<IReassignedVariableService>();
-
-                var extensionManager = document.Project.Solution.Services.GetRequiredService<IExtensionManager>();
-                var classifiers = classificationService.GetDefaultSyntaxClassifiers();
-
-                var getNodeClassifiers = extensionManager.CreateNodeExtensionGetter(classifiers, c => c.SyntaxNodeTypes);
-                var getTokenClassifiers = extensionManager.CreateTokenExtensionGetter(classifiers, c => c.SyntaxTokenKinds);
-
-                await classificationService.AddSemanticClassificationsAsync(
-                    document, textSpans, options, getNodeClassifiers, getTokenClassifiers, result, cancellationToken).ConfigureAwait(false);
-
-                if (options.ClassifyReassignedVariables)
-                {
-                    for (var i = 0; i < textSpans.Length; i++)
-                    {
-                        var textSpan = textSpans[i];
-                        var classifiedSpans = result[i].Object;
-                        var reassignedVariableSpans = await reassignedVariableService.GetLocationsAsync(document, textSpan, cancellationToken).ConfigureAwait(false);
-                        foreach (var span in reassignedVariableSpans)
-                            classifiedSpans.Add(new ClassifiedSpan(span, ClassificationTypeNames.ReassignedVariable));
-                    }
-                }
-            }
-            else if (type == ClassificationType.EmbeddedLanguage)
-            {
-                var embeddedLanguageService = document.GetLanguageService<IEmbeddedLanguageClassificationService>();
-                if (embeddedLanguageService != null)
-                {
-                    await embeddedLanguageService.AddEmbeddedLanguageClassificationsAsync(
-                        document, textSpans, options, result, cancellationToken).ConfigureAwait(false);
-                }
-            }
-            else
-            {
-                throw ExceptionUtilities.UnexpectedValue(type);
-            }
-        }
-
-        private static async Task AddClassificationsAsync(
-            Document document,
-            TextSpan textSpan,
-            ClassificationOptions options,
-            ClassificationType type,
-            SegmentedList<ClassifiedSpan> result,
-            CancellationToken cancellationToken)
-        {
-            var classificationService = document.GetLanguageService<ISyntaxClassificationService>();
-            if (classificationService == null)
-            {
-                // When renaming a file's extension through VS when it's opened in editor, 
-                // the content type might change and the content type changed event can be 
-                // raised before the renaming propagate through VS workspace. As a result, 
-                // the document we got (based on the buffer) could still be the one in the workspace
-                // before rename happened. This would cause us problem if the document is supported 
-                // by workspace but not a roslyn language (e.g. xaml, F#, etc.), since none of the roslyn 
-                // language services would be available.
-                //
-                // If this is the case, we will simply bail out. It's OK to ignore the request
-                // because when the buffer eventually get associated with the correct document in roslyn
-                // workspace, we will be invoked again.
-                //
-                // For example, if you open a xaml from from a WPF project in designer view,
-                // and then rename file extension from .xaml to .cs, then the document we received
-                // here would still belong to the special "-xaml" project.
-                return;
-            }
-
-            var client = await RemoteHostClient.TryGetClientAsync(document.Project, cancellationToken).ConfigureAwait(false);
-            if (client != null)
-            {
-                // We have an oop connection.  If we're not fully loaded, see if we can retrieve a previously cached set
-                // of classifications from the server.  Note: this must be a separate call (instead of being part of
-                // service.GetSemanticClassificationsAsync below) as we want to try to read in the cached
-                // classifications without doing any syncing to the OOP process.
-                var isFullyLoaded = IsFullyLoaded(document, cancellationToken);
-                if (await TryGetCachedClassificationsAsync(document, textSpan, type, client, isFullyLoaded, result, cancellationToken).ConfigureAwait(false))
-                    return;
-
-                // Call the project overload.  Semantic classification only needs the current project's information
-                // to classify properly.
-                var classifiedSpans = await client.TryInvokeAsync<IRemoteSemanticClassificationService, SerializableClassifiedSpans>(
-                   document.Project,
-                   (service, solutionInfo, cancellationToken) => service.GetClassificationsAsync(
-                       solutionInfo, document.Id, textSpan, type, options, isFullyLoaded, cancellationToken),
-                   cancellationToken).ConfigureAwait(false);
-
-                // if the remote call fails do nothing (error has already been reported)
-                if (classifiedSpans.HasValue)
-                    classifiedSpans.Value.Rehydrate(result);
-            }
-            else
-            {
-                await AddClassificationsInCurrentProcessAsync(
-                    document, textSpan, type, options, result, cancellationToken).ConfigureAwait(false);
-            }
-        }
-
         private static bool IsFullyLoaded(Document document, CancellationToken cancellationToken)
         {
             var workspaceStatusService = document.Project.Solution.Services.GetRequiredService<IWorkspaceStatusService>();
@@ -208,45 +95,91 @@ namespace Microsoft.CodeAnalysis.Classification
 
         public static async Task AddClassificationsInCurrentProcessAsync(
             Document document,
-            TextSpan textSpan,
-            ClassificationType type,
+            ImmutableArray<TextSpan> textSpans,
             ClassificationOptions options,
-            SegmentedList<ClassifiedSpan> result,
+            ClassificationType type,
+            ArrayBuilder<PooledObject<SegmentedList<ClassifiedSpan>>> result,
             CancellationToken cancellationToken)
         {
-            if (type == ClassificationType.Semantic)
+            var classificationService = document.GetLanguageService<ISyntaxClassificationService>();
+            if (classificationService == null)
             {
-                var classificationService = document.GetRequiredLanguageService<ISyntaxClassificationService>();
-                var reassignedVariableService = document.GetRequiredLanguageService<IReassignedVariableService>();
-
-                var extensionManager = document.Project.Solution.Services.GetRequiredService<IExtensionManager>();
-                var classifiers = classificationService.GetDefaultSyntaxClassifiers();
-
-                var getNodeClassifiers = extensionManager.CreateNodeExtensionGetter(classifiers, c => c.SyntaxNodeTypes);
-                var getTokenClassifiers = extensionManager.CreateTokenExtensionGetter(classifiers, c => c.SyntaxTokenKinds);
-
-                await classificationService.AddSemanticToBeRemovedAsync(
-                    document, textSpan, options, getNodeClassifiers, getTokenClassifiers, result, cancellationToken).ConfigureAwait(false);
-
-                if (options.ClassifyReassignedVariables)
-                {
-                    var reassignedVariableSpans = await reassignedVariableService.GetLocationsAsync(document, textSpan, cancellationToken).ConfigureAwait(false);
-                    foreach (var span in reassignedVariableSpans)
-                        result.Add(new ClassifiedSpan(span, ClassificationTypeNames.ReassignedVariable));
-                }
+                return;
             }
-            else if (type == ClassificationType.EmbeddedLanguage)
+
+            var client = await RemoteHostClient.TryGetClientAsync(document.Project, cancellationToken).ConfigureAwait(false);
+            if (client != null)
             {
-                var embeddedLanguageService = document.GetLanguageService<IEmbeddedLanguageClassificationService>();
-                if (embeddedLanguageService != null)
+                // We have an oop connection.  If we're not fully loaded, see if we can retrieve a previously cached set
+                // of classifications from the server.  Note: this must be a separate call (instead of being part of
+                // service.GetSemanticClassificationsAsync below) as we want to try to read in the cached
+                // classifications without doing any syncing to the OOP process.
+                var isFullyLoaded = IsFullyLoaded(document, cancellationToken);
+                for (var i = 0; i < textSpans.Length; i++)
                 {
-                    await embeddedLanguageService.AddEmbeddedToBeRemovedAsync(
-                        document, textSpan, options, result, cancellationToken).ConfigureAwait(false);
+                    var textSpan = textSpans[i];
+                    if (await TryGetCachedClassificationsAsync(document, textSpan, type, client, isFullyLoaded, result[i].Object, cancellationToken).ConfigureAwait(false))
+                        return;
+
+                    // Call the project overload.  Semantic classification only needs the current project's information
+                    // to classify properly.
+                    var classifiedSpans = await client.TryInvokeAsync<IRemoteSemanticClassificationService, SerializableClassifiedSpans[]>(
+                       document.Project,
+                       (service, solutionInfo, cancellationToken) => service.GetClassificationsAsync(
+                           solutionInfo, document.Id, textSpans, type, options, result, isFullyLoaded, cancellationToken),
+                       cancellationToken).ConfigureAwait(false);
+
+                    // if the remote call fails do nothing (error has already been reported)
+                    if (classifiedSpans.HasValue)
+                    {
+                        for (var j = 0; j < classifiedSpans.Value.Length; j++)
+                        {
+                            var curSpan = classifiedSpans.Value[j];
+                            curSpan.Rehydrate(result[i].Object);
+                        }
+                    }
                 }
             }
             else
             {
-                throw ExceptionUtilities.UnexpectedValue(type);
+                if (type == ClassificationType.Semantic)
+                {
+                    var reassignedVariableService = document.GetRequiredLanguageService<IReassignedVariableService>();
+
+                    var extensionManager = document.Project.Solution.Services.GetRequiredService<IExtensionManager>();
+                    var classifiers = classificationService.GetDefaultSyntaxClassifiers();
+
+                    var getNodeClassifiers = extensionManager.CreateNodeExtensionGetter(classifiers, c => c.SyntaxNodeTypes);
+                    var getTokenClassifiers = extensionManager.CreateTokenExtensionGetter(classifiers, c => c.SyntaxTokenKinds);
+
+                    await classificationService.AddSemanticClassificationsAsync(
+                        document, textSpans, options, getNodeClassifiers, getTokenClassifiers, result, cancellationToken).ConfigureAwait(false);
+
+                    if (options.ClassifyReassignedVariables)
+                    {
+                        for (var i = 0; i < textSpans.Length; i++)
+                        {
+                            var textSpan = textSpans[i];
+                            var classifiedSpans = result[i].Object;
+                            var reassignedVariableSpans = await reassignedVariableService.GetLocationsAsync(document, textSpan, cancellationToken).ConfigureAwait(false);
+                            foreach (var span in reassignedVariableSpans)
+                                classifiedSpans.Add(new ClassifiedSpan(span, ClassificationTypeNames.ReassignedVariable));
+                        }
+                    }
+                }
+                else if (type == ClassificationType.EmbeddedLanguage)
+                {
+                    var embeddedLanguageService = document.GetLanguageService<IEmbeddedLanguageClassificationService>();
+                    if (embeddedLanguageService != null)
+                    {
+                        await embeddedLanguageService.AddEmbeddedLanguageClassificationsAsync(
+                            document, textSpans, options, result, cancellationToken).ConfigureAwait(false);
+                    }
+                }
+                else
+                {
+                    throw ExceptionUtilities.UnexpectedValue(type);
+                }
             }
         }
 
@@ -288,6 +221,27 @@ namespace Microsoft.CodeAnalysis.Classification
         {
             var classificationService = services.GetLanguageServices(oldRoot.Language).GetService<ISyntaxClassificationService>();
             return classificationService?.ComputeSyntacticChangeRange(oldRoot, newRoot, timeout, cancellationToken);
+        }
+
+        private static Task AddClassificationsAsync(
+            Document document,
+            TextSpan textSpan,
+            ClassificationOptions options,
+            ClassificationType type,
+            SegmentedList<ClassifiedSpan> result,
+            CancellationToken cancellationToken)
+        {
+            using var _1 = ArrayBuilder<PooledObject<SegmentedList<ClassifiedSpan>>>.GetInstance(out var tempArray);
+            using var _2 = ArrayBuilder<TextSpan>.GetInstance(out var textSpans);
+            textSpans.Add(textSpan);
+            tempArray.Add(Classifier.GetPooledList(out _));
+            result = tempArray[0].Object;
+            return Task.Run(async () =>
+            {
+                await AddClassificationsInCurrentProcessAsync(document, textSpans.ToImmutableAndClear(), options, type, tempArray, cancellationToken)
+                    .ConfigureAwait(false);
+                result = tempArray[0].Object;
+            }, cancellationToken);
         }
     }
 }

--- a/src/Workspaces/Core/Portable/Classification/AbstractClassificationService.cs
+++ b/src/Workspaces/Core/Portable/Classification/AbstractClassificationService.cs
@@ -38,7 +38,7 @@ namespace Microsoft.CodeAnalysis.Classification
         }
 
         public Task AddSemanticClassificationsAsync(
-            Document document, ImmutableArray<TextSpan> textSpans, ClassificationOptions options, ArrayBuilder<SegmentedList<ClassifiedSpan>> result, CancellationToken cancellationToken)
+            Document document, ImmutableArray<TextSpan> textSpans, ClassificationOptions options, ArrayBuilder<PooledObject<SegmentedList<ClassifiedSpan>>> result, CancellationToken cancellationToken)
         {
             return Task.CompletedTask;
         }

--- a/src/Workspaces/Core/Portable/Classification/AbstractClassificationService.cs
+++ b/src/Workspaces/Core/Portable/Classification/AbstractClassificationService.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Collections;
@@ -24,7 +25,7 @@ namespace Microsoft.CodeAnalysis.Classification
         public abstract void AddLexicalClassifications(SourceText text, TextSpan textSpan, SegmentedList<ClassifiedSpan> result, CancellationToken cancellationToken);
         public abstract ClassifiedSpan AdjustStaleClassification(SourceText text, ClassifiedSpan classifiedSpan);
 
-        public Task AddSemanticClassificationsAsync(
+        public Task ToBeRemovedAsync(
             Document document, TextSpan textSpan, ClassificationOptions options, SegmentedList<ClassifiedSpan> result, CancellationToken cancellationToken)
         {
             return AddClassificationsAsync(document, textSpan, options, ClassificationType.Semantic, result, cancellationToken);
@@ -34,6 +35,12 @@ namespace Microsoft.CodeAnalysis.Classification
             Document document, TextSpan textSpan, ClassificationOptions options, SegmentedList<ClassifiedSpan> result, CancellationToken cancellationToken)
         {
             return AddClassificationsAsync(document, textSpan, options, ClassificationType.EmbeddedLanguage, result, cancellationToken);
+        }
+
+        public Task AddSemanticClassificationsAsync(
+            Document document, ImmutableArray<TextSpan> textSpans, ClassificationOptions options, ArrayBuilder<SegmentedList<ClassifiedSpan>> result, CancellationToken cancellationToken)
+        {
+            return Task.CompletedTask;
         }
 
         private static async Task AddClassificationsAsync(
@@ -158,7 +165,7 @@ namespace Microsoft.CodeAnalysis.Classification
                 var getNodeClassifiers = extensionManager.CreateNodeExtensionGetter(classifiers, c => c.SyntaxNodeTypes);
                 var getTokenClassifiers = extensionManager.CreateTokenExtensionGetter(classifiers, c => c.SyntaxTokenKinds);
 
-                await classificationService.AddSemanticClassificationsAsync(
+                await classificationService.ToBeRemovedAsync(
                     document, textSpan, options, getNodeClassifiers, getTokenClassifiers, result, cancellationToken).ConfigureAwait(false);
 
                 if (options.ClassifyReassignedVariables)

--- a/src/Workspaces/Core/Portable/Classification/ClassifierHelper.cs
+++ b/src/Workspaces/Core/Portable/Classification/ClassifierHelper.cs
@@ -115,8 +115,8 @@ namespace Microsoft.CodeAnalysis.Classification
             using var _2 = ArrayBuilder<PooledObject<SegmentedList<ClassifiedSpan>>>.GetInstance(out var semanticSpansArray);
             for (var i = 0; i < spans.Length; i++)
             {
-                syntacticSpansArray[i] = Classifier.GetPooledList(out _);
-                semanticSpansArray[i] = Classifier.GetPooledList(out _);
+                syntacticSpansArray.Add(Classifier.GetPooledList(out _));
+                semanticSpansArray.Add(Classifier.GetPooledList(out _));
             }
 
             try

--- a/src/Workspaces/Core/Portable/Classification/ClassifierHelper.cs
+++ b/src/Workspaces/Core/Portable/Classification/ClassifierHelper.cs
@@ -34,7 +34,7 @@ namespace Microsoft.CodeAnalysis.Classification
         {
             using var _ = ArrayBuilder<ClassifiedSpan>.GetInstance(out var flatten);
             var classifiedSpans = await GetNewClassifiedSpansAsync(document, spans, options, includeAdditiveSpans, cancellationToken).ConfigureAwait(false);
-  
+
             for (var i = 0; i < classifiedSpans.Length; i++)
             {
                 var classifiedSpan = classifiedSpans[i];
@@ -81,8 +81,8 @@ namespace Microsoft.CodeAnalysis.Classification
 
             // Intentional that we're adding both semantic and embedded lang classifications to the same array.  Both
             // are 'semantic' from the perspective of this helper method.
-            await classificationService.ToBeRemovedAsync(document, span, options, semanticSpans, cancellationToken).ConfigureAwait(false);
-            await classificationService.AddEmbeddedLanguageClassificationsAsync(document, span, options, semanticSpans, cancellationToken).ConfigureAwait(false);
+            await classificationService.AddSemanticToBeRemovedAsync(document, span, options, semanticSpans, cancellationToken).ConfigureAwait(false);
+            await classificationService.AddEmbeddedToBeRemovedAsync(document, span, options, semanticSpans, cancellationToken).ConfigureAwait(false);
 
             // MergeClassifiedSpans will ultimately filter multiple classifications for the same
             // span down to one. We know that additive classifications are there just to 
@@ -129,12 +129,7 @@ namespace Microsoft.CodeAnalysis.Classification
                 }
 
                 await classificationService.AddSemanticClassificationsAsync(document, spans, options, semanticSpansArray, cancellationToken).ConfigureAwait(false);
-                for (var i = 0; i < spans.Length; i++)
-                {
-                    var span = spans[i];
-                    await classificationService.AddEmbeddedLanguageClassificationsAsync(document, span, options, syntacticSpansArray[i].Object, cancellationToken).ConfigureAwait(false);
-                    semanticSpansArray.Add(semanticSpansArray[i]);
-                }
+                await classificationService.AddEmbeddedLanguageClassificationsAsync(document, spans, options, semanticSpansArray, cancellationToken).ConfigureAwait(false);
 
                 using var _3 = ArrayBuilder<ImmutableArray<ClassifiedSpan>>.GetInstance(out var classifiedSpans);
                 for (var i = 0; i < spans.Length; i++)

--- a/src/Workspaces/Core/Portable/Classification/IClassificationService.cs
+++ b/src/Workspaces/Core/Portable/Classification/IClassificationService.cs
@@ -54,13 +54,14 @@ namespace Microsoft.CodeAnalysis.Classification
         /// </remarks>
         Task AddSemanticClassificationsAsync(Document document, ImmutableArray<TextSpan> textSpans, ClassificationOptions options, ArrayBuilder<PooledObject<SegmentedList<ClassifiedSpan>>> result, CancellationToken cancellationToken);
 
-        Task ToBeRemovedAsync(Document document, TextSpan textSpan, ClassificationOptions options, SegmentedList<ClassifiedSpan> result, CancellationToken cancellationToken);
+        Task AddSemanticToBeRemovedAsync(Document document, TextSpan textSpan, ClassificationOptions options, SegmentedList<ClassifiedSpan> result, CancellationToken cancellationToken);
 
         /// <summary>
         /// Produce the classifications for embedded language string literals (e.g. Regex/Json strings) in the span of
         /// text specified.
         /// </summary>
-        Task AddEmbeddedLanguageClassificationsAsync(Document document, TextSpan textSpan, ClassificationOptions options, SegmentedList<ClassifiedSpan> result, CancellationToken cancellationToken);
+        Task AddEmbeddedLanguageClassificationsAsync(Document document, ImmutableArray<TextSpan> textSpans, ClassificationOptions options, ArrayBuilder<PooledObject<SegmentedList<ClassifiedSpan>>> result, CancellationToken cancellationToken);
+        Task AddEmbeddedToBeRemovedAsync(Document document, TextSpan textSpan, ClassificationOptions options, SegmentedList<ClassifiedSpan> result, CancellationToken cancellationToken);
 
         /// <summary>
         /// Adjust a classification from a previous version of text accordingly based on the current

--- a/src/Workspaces/Core/Portable/Classification/IClassificationService.cs
+++ b/src/Workspaces/Core/Portable/Classification/IClassificationService.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Collections;
@@ -51,7 +52,9 @@ namespace Microsoft.CodeAnalysis.Classification
         /// This will not include classifications for embedded language constructs in string literals.  For that use
         /// <see cref="AddEmbeddedLanguageClassificationsAsync"/>.
         /// </remarks>
-        Task AddSemanticClassificationsAsync(Document document, TextSpan textSpan, ClassificationOptions options, SegmentedList<ClassifiedSpan> result, CancellationToken cancellationToken);
+        Task AddSemanticClassificationsAsync(Document document, ImmutableArray<TextSpan> textSpans, ClassificationOptions options, ArrayBuilder<SegmentedList<ClassifiedSpan>> result, CancellationToken cancellationToken);
+
+        Task ToBeRemovedAsync(Document document, TextSpan textSpan, ClassificationOptions options, SegmentedList<ClassifiedSpan> result, CancellationToken cancellationToken);
 
         /// <summary>
         /// Produce the classifications for embedded language string literals (e.g. Regex/Json strings) in the span of

--- a/src/Workspaces/Core/Portable/Classification/IClassificationService.cs
+++ b/src/Workspaces/Core/Portable/Classification/IClassificationService.cs
@@ -52,7 +52,7 @@ namespace Microsoft.CodeAnalysis.Classification
         /// This will not include classifications for embedded language constructs in string literals.  For that use
         /// <see cref="AddEmbeddedLanguageClassificationsAsync"/>.
         /// </remarks>
-        Task AddSemanticClassificationsAsync(Document document, ImmutableArray<TextSpan> textSpans, ClassificationOptions options, ArrayBuilder<SegmentedList<ClassifiedSpan>> result, CancellationToken cancellationToken);
+        Task AddSemanticClassificationsAsync(Document document, ImmutableArray<TextSpan> textSpans, ClassificationOptions options, ArrayBuilder<PooledObject<SegmentedList<ClassifiedSpan>>> result, CancellationToken cancellationToken);
 
         Task ToBeRemovedAsync(Document document, TextSpan textSpan, ClassificationOptions options, SegmentedList<ClassifiedSpan> result, CancellationToken cancellationToken);
 

--- a/src/Workspaces/Core/Portable/Classification/IEmbeddedLanguageClassificationService.cs
+++ b/src/Workspaces/Core/Portable/Classification/IEmbeddedLanguageClassificationService.cs
@@ -2,21 +2,30 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.Host;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.Classification
 {
     internal interface IEmbeddedLanguageClassificationService : ILanguageService
     {
-        Task AddEmbeddedLanguageClassificationsAsync(
+        Task AddEmbeddedToBeRemovedAsync(
             Document document,
             TextSpan textSpan,
             ClassificationOptions options,
             SegmentedList<ClassifiedSpan> result,
+            CancellationToken cancellationToken);
+
+        Task AddEmbeddedLanguageClassificationsAsync(
+            Document document,
+            ImmutableArray<TextSpan> textSpans,
+            ClassificationOptions options,
+            ArrayBuilder<PooledObject<SegmentedList<ClassifiedSpan>>> result,
             CancellationToken cancellationToken);
 
         void AddEmbeddedLanguageClassifications(

--- a/src/Workspaces/Core/Portable/Classification/IEmbeddedLanguageClassificationService.cs
+++ b/src/Workspaces/Core/Portable/Classification/IEmbeddedLanguageClassificationService.cs
@@ -6,7 +6,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.Host;
-using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.Classification

--- a/src/Workspaces/Core/Portable/Classification/IRemoteSemanticClassificationService.cs
+++ b/src/Workspaces/Core/Portable/Classification/IRemoteSemanticClassificationService.cs
@@ -17,12 +17,13 @@ namespace Microsoft.CodeAnalysis.Classification
 {
     internal interface IRemoteSemanticClassificationService
     {
-        ValueTask<SerializableClassifiedSpans> GetClassificationsAsync(
+        ValueTask<SerializableClassifiedSpans[]> GetClassificationsAsync(
             Checksum solutionChecksum,
             DocumentId documentId,
-            TextSpan span,
+            ImmutableArray<TextSpan> textSpans,
             ClassificationType type,
             ClassificationOptions options,
+            ArrayBuilder<PooledObject<SegmentedList<ClassifiedSpan>>> result,
             bool isFullyLoaded,
             CancellationToken cancellationToken);
 

--- a/src/Workspaces/Core/Portable/Classification/IRemoteSemanticClassificationService.cs
+++ b/src/Workspaces/Core/Portable/Classification/IRemoteSemanticClassificationService.cs
@@ -17,7 +17,16 @@ namespace Microsoft.CodeAnalysis.Classification
 {
     internal interface IRemoteSemanticClassificationService
     {
-        ValueTask<SerializableClassifiedSpans[]> GetClassificationsAsync(
+        ValueTask<SerializableClassifiedSpans> GetClassificationsAsync(
+            Checksum solutionChecksum,
+            DocumentId documentId,
+            TextSpan span,
+            ClassificationType type,
+            ClassificationOptions options,
+            bool isFullyLoaded,
+            CancellationToken cancellationToken);
+
+        ValueTask<ArrayBuilder<SerializableClassifiedSpans>> GetClassificationsAsync(
             Checksum solutionChecksum,
             DocumentId documentId,
             ImmutableArray<TextSpan> textSpans,
@@ -36,6 +45,19 @@ namespace Microsoft.CodeAnalysis.Classification
         ValueTask<SerializableClassifiedSpans?> GetCachedClassificationsAsync(
             DocumentKey documentKey,
             TextSpan textSpan,
+            ClassificationType type,
+            Checksum checksum,
+            CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Tries to get cached semantic classifications for the specified document and the specified <paramref
+        /// name="textSpans"/>.  Will return an empty array not able to.
+        /// </summary>
+        /// <param name="checksum">Pass in <see cref="DocumentStateChecksums.Text"/>.  This will ensure that the cached
+        /// classifications are only returned if they match the content the file currently has.</param>
+        ValueTask<ArrayBuilder<SerializableClassifiedSpans>?> GetCachedClassificationsAsync(
+            DocumentKey documentKey,
+            ImmutableArray<TextSpan> textSpans,
             ClassificationType type,
             Checksum checksum,
             CancellationToken cancellationToken);

--- a/src/Workspaces/Core/Portable/Classification/SyntaxClassification/AbstractSyntaxClassificationService.cs
+++ b/src/Workspaces/Core/Portable/Classification/SyntaxClassification/AbstractSyntaxClassificationService.cs
@@ -35,7 +35,7 @@ namespace Microsoft.CodeAnalysis.Classification
             ClassificationOptions options,
             Func<SyntaxNode, ImmutableArray<ISyntaxClassifier>> getNodeClassifiers,
             Func<SyntaxToken, ImmutableArray<ISyntaxClassifier>> getTokenClassifiers,
-            ArrayBuilder<SegmentedList<ClassifiedSpan>> result,
+            ArrayBuilder<PooledObject<SegmentedList<ClassifiedSpan>>> result,
             CancellationToken cancellationToken)
         {
             try
@@ -43,9 +43,7 @@ namespace Microsoft.CodeAnalysis.Classification
                 var semanticModel = await document.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
                 for (var i = 0; i < textSpans.Length; i++)
                 {
-                    using var _1 = Classifier.GetPooledList(out var semanticSpans);
-                    AddSemanticClassifications(semanticModel, textSpans[i], getNodeClassifiers, getTokenClassifiers, semanticSpans, options, cancellationToken);
-                    result.Add(semanticSpans);
+                    AddSemanticClassifications(semanticModel, textSpans[i], getNodeClassifiers, getTokenClassifiers, result[i].Object, options, cancellationToken);
                 }
             }
             catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e, cancellationToken))

--- a/src/Workspaces/Core/Portable/Classification/SyntaxClassification/AbstractSyntaxClassificationService.cs
+++ b/src/Workspaces/Core/Portable/Classification/SyntaxClassification/AbstractSyntaxClassificationService.cs
@@ -31,6 +31,31 @@ namespace Microsoft.CodeAnalysis.Classification
 
         public async Task AddSemanticClassificationsAsync(
             Document document,
+            ImmutableArray<TextSpan> textSpans,
+            ClassificationOptions options,
+            Func<SyntaxNode, ImmutableArray<ISyntaxClassifier>> getNodeClassifiers,
+            Func<SyntaxToken, ImmutableArray<ISyntaxClassifier>> getTokenClassifiers,
+            ArrayBuilder<SegmentedList<ClassifiedSpan>> result,
+            CancellationToken cancellationToken)
+        {
+            try
+            {
+                var semanticModel = await document.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+                for (var i = 0; i < textSpans.Length; i++)
+                {
+                    using var _1 = Classifier.GetPooledList(out var semanticSpans);
+                    AddSemanticClassifications(semanticModel, textSpans[i], getNodeClassifiers, getTokenClassifiers, semanticSpans, options, cancellationToken);
+                    result.Add(semanticSpans);
+                }
+            }
+            catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e, cancellationToken))
+            {
+                throw ExceptionUtilities.Unreachable();
+            }
+        }
+
+        public async Task ToBeRemovedAsync(
+            Document document,
             TextSpan textSpan,
             ClassificationOptions options,
             Func<SyntaxNode, ImmutableArray<ISyntaxClassifier>> getNodeClassifiers,

--- a/src/Workspaces/Core/Portable/Classification/SyntaxClassification/AbstractSyntaxClassificationService.cs
+++ b/src/Workspaces/Core/Portable/Classification/SyntaxClassification/AbstractSyntaxClassificationService.cs
@@ -52,7 +52,7 @@ namespace Microsoft.CodeAnalysis.Classification
             }
         }
 
-        public async Task ToBeRemovedAsync(
+        public async Task AddSemanticToBeRemovedAsync(
             Document document,
             TextSpan textSpan,
             ClassificationOptions options,

--- a/src/Workspaces/Core/Portable/Classification/SyntaxClassification/ISyntaxClassificationService.cs
+++ b/src/Workspaces/Core/Portable/Classification/SyntaxClassification/ISyntaxClassificationService.cs
@@ -40,8 +40,8 @@ namespace Microsoft.CodeAnalysis.Classification
             ArrayBuilder<PooledObject<SegmentedList<ClassifiedSpan>>> result,
             CancellationToken cancellationToken);
 
-        /// <inheritdoc cref="IClassificationService.ToBeRemovedAsync"/>
-        Task ToBeRemovedAsync(
+        /// <inheritdoc cref="IClassificationService.AddSemanticToBeRemovedAsync"/>
+        Task AddSemanticToBeRemovedAsync(
             Document document,
             TextSpan textSpan,
             ClassificationOptions options,

--- a/src/Workspaces/Core/Portable/Classification/SyntaxClassification/ISyntaxClassificationService.cs
+++ b/src/Workspaces/Core/Portable/Classification/SyntaxClassification/ISyntaxClassificationService.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Classification.Classifiers;
 using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.Host;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.Classification
@@ -30,8 +31,17 @@ namespace Microsoft.CodeAnalysis.Classification
             SegmentedList<ClassifiedSpan> result,
             CancellationToken cancellationToken);
 
-        /// <inheritdoc cref="IClassificationService.AddSemanticClassificationsAsync"/>
         Task AddSemanticClassificationsAsync(
+            Document document,
+            ImmutableArray<TextSpan> textSpans,
+            ClassificationOptions options,
+            Func<SyntaxNode, ImmutableArray<ISyntaxClassifier>> getNodeClassifiers,
+            Func<SyntaxToken, ImmutableArray<ISyntaxClassifier>> getTokenClassifiers,
+            ArrayBuilder<SegmentedList<ClassifiedSpan>> result,
+            CancellationToken cancellationToken);
+
+        /// <inheritdoc cref="IClassificationService.ToBeRemovedAsync"/>
+        Task ToBeRemovedAsync(
             Document document,
             TextSpan textSpan,
             ClassificationOptions options,

--- a/src/Workspaces/Core/Portable/Classification/SyntaxClassification/ISyntaxClassificationService.cs
+++ b/src/Workspaces/Core/Portable/Classification/SyntaxClassification/ISyntaxClassificationService.cs
@@ -37,7 +37,7 @@ namespace Microsoft.CodeAnalysis.Classification
             ClassificationOptions options,
             Func<SyntaxNode, ImmutableArray<ISyntaxClassifier>> getNodeClassifiers,
             Func<SyntaxToken, ImmutableArray<ISyntaxClassifier>> getTokenClassifiers,
-            ArrayBuilder<SegmentedList<ClassifiedSpan>> result,
+            ArrayBuilder<PooledObject<SegmentedList<ClassifiedSpan>>> result,
             CancellationToken cancellationToken);
 
         /// <inheritdoc cref="IClassificationService.ToBeRemovedAsync"/>

--- a/src/Workspaces/Remote/ServiceHub/Services/SemanticClassification/RemoteSemanticClassificationService.Caching.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/SemanticClassification/RemoteSemanticClassificationService.Caching.cs
@@ -136,7 +136,7 @@ namespace Microsoft.CodeAnalysis.Remote
 
             // Compute classifications for the full span.
             var text = await document.GetValueTextAsync(cancellationToken).ConfigureAwait(false);
-            await classificationService.ToBeRemovedAsync(document, new TextSpan(0, text.Length), options, classifiedSpans, cancellationToken).ConfigureAwait(false);
+            await classificationService.AddSemanticToBeRemovedAsync(document, new TextSpan(0, text.Length), options, classifiedSpans, cancellationToken).ConfigureAwait(false);
 
             using var stream = SerializableBytes.CreateWritableStream();
             using (var writer = new ObjectWriter(stream, leaveOpen: true, cancellationToken))

--- a/src/Workspaces/Remote/ServiceHub/Services/SemanticClassification/RemoteSemanticClassificationService.Caching.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/SemanticClassification/RemoteSemanticClassificationService.Caching.cs
@@ -136,7 +136,7 @@ namespace Microsoft.CodeAnalysis.Remote
 
             // Compute classifications for the full span.
             var text = await document.GetValueTextAsync(cancellationToken).ConfigureAwait(false);
-            await classificationService.AddSemanticClassificationsAsync(document, new TextSpan(0, text.Length), options, classifiedSpans, cancellationToken).ConfigureAwait(false);
+            await classificationService.ToBeRemovedAsync(document, new TextSpan(0, text.Length), options, classifiedSpans, cancellationToken).ConfigureAwait(false);
 
             using var stream = SerializableBytes.CreateWritableStream();
             using (var writer = new ObjectWriter(stream, leaveOpen: true, cancellationToken))

--- a/src/Workspaces/Remote/ServiceHub/Services/SemanticClassification/RemoteSemanticClassificationService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/SemanticClassification/RemoteSemanticClassificationService.cs
@@ -21,7 +21,7 @@ namespace Microsoft.CodeAnalysis.Remote
                 => new RemoteSemanticClassificationService(arguments);
         }
 
-        public ValueTask<SerializableClassifiedSpans[]> GetClassificationsAsync(
+        public ValueTask<ArrayBuilder<SerializableClassifiedSpans>> GetClassificationsAsync(
             Checksum solutionChecksum,
             DocumentId documentId,
             ImmutableArray<TextSpan> spans,
@@ -56,13 +56,52 @@ namespace Microsoft.CodeAnalysis.Remote
                     _workQueue.AddWork((document, type, options));
                 }
 
-                var serializableClassifiedSpans = new SerializableClassifiedSpans[spans.Length];
+                using var _ = ArrayBuilder<SerializableClassifiedSpans>.GetInstance(out var serializableSpans);
                 for (var i = 0; i < spans.Length; i++)
                 {
-                    SerializableClassifiedSpans.Dehydrate(result[i].Object.ToImmutableArray());
+                    serializableSpans.Add(SerializableClassifiedSpans.Dehydrate(result[i].Object.ToImmutableArray()));
                 }
 
-                return serializableClassifiedSpans;
+                return serializableSpans;
+            }, cancellationToken);
+        }
+
+        public ValueTask<SerializableClassifiedSpans> GetClassificationsAsync(
+            Checksum solutionChecksum,
+            DocumentId documentId,
+            TextSpan span,
+            ClassificationType type,
+            ClassificationOptions options,
+            bool isFullyLoaded,
+            CancellationToken cancellationToken)
+        {
+            return RunServiceAsync(solutionChecksum, async solution =>
+            {
+                var document = solution.GetDocument(documentId) ?? await solution.GetSourceGeneratedDocumentAsync(documentId, cancellationToken).ConfigureAwait(false);
+                Contract.ThrowIfNull(document);
+
+                if (options.ForceFrozenPartialSemanticsForCrossProcessOperations)
+                {
+                    // Frozen partial semantics is not automatically passed to OOP, so enable it explicitly when desired
+                    document = document.WithFrozenPartialSemantics(cancellationToken);
+                }
+
+                using var _ = Classifier.GetPooledList(out var temp);
+                await AbstractClassificationService.AddClassificationsInCurrentProcessAsync(
+                    document, span, type, options, temp, cancellationToken).ConfigureAwait(false);
+
+                if (isFullyLoaded)
+                {
+                    // Once fully loaded, there's no need for us to keep around any of the data we cached in-memory
+                    // during the time the solution was loading.
+                    lock (_cachedData)
+                        _cachedData.Clear();
+
+                    // Enqueue this document into our work queue to fully classify and cache.
+                    _workQueue.AddWork((document, type, options));
+                }
+
+                return SerializableClassifiedSpans.Dehydrate(temp.ToImmutableArray());
             }, cancellationToken);
         }
     }

--- a/src/Workspaces/Remote/ServiceHub/Services/SemanticClassification/RemoteSemanticClassificationService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/SemanticClassification/RemoteSemanticClassificationService.cs
@@ -6,8 +6,6 @@ using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Classification;
-using Microsoft.CodeAnalysis.PooledObjects;
-using Microsoft.CodeAnalysis.Storage;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
 


### PR DESCRIPTION
Experiments done:

- [x] Removes the bottleneck with `AddSemanticClassificationsAsync` when feature flag is turned on. but it has caching disabled for multiple ranges

- [x] Tried a side by side experiment between: 
(a) without changes in this PR (feature flag off)
(b) with changes in this PR when feature flag is turned on. 
![image](https://github.com/maryamariyan/roslyn/assets/5897654/2ee896fb-409b-49e3-b1b5-a7583ab153bf)
(For more info on screenshot refer to commit https://github.com/maryamariyan/roslyn/pull/1/commits/16e59349fbe13051e1556143a4066c569238e4a9) we get better performance when opening a very large razor file with many tokens
